### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/jihadajdev/c41694a7-a877-4bfd-ba36-9f9314d0f865/6f3b5cf9-cad1-4eca-87b5-6bbd56a6a7f1/_apis/work/boardbadge/d990c3cd-01c8-402f-a1e9-49e8230ae426)](https://dev.azure.com/jihadajdev/c41694a7-a877-4bfd-ba36-9f9314d0f865/_boards/board/t/6f3b5cf9-cad1-4eca-87b5-6bbd56a6a7f1/Microsoft.RequirementCategory)
 # jihadaj.github.io
 About Me


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/jihadajdev/c41694a7-a877-4bfd-ba36-9f9314d0f865/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.